### PR TITLE
Fix various functions

### DIFF
--- a/gtkfilechooser.defs
+++ b/gtkfilechooser.defs
@@ -92,7 +92,7 @@
 (define-func gtk_file_chooser_unselect_filename
   none
   ((GtkFileChooser chooser)
-   ((tvec string in) filename)))
+   (string filename)))
 
 (define-func gtk_file_chooser_select_all
   none
@@ -110,7 +110,7 @@
 (define-func gtk_file_chooser_set_current_folder
   bool
   ((GtkFileChooser chooser)
-   ((tvec string in) folder)))
+   (string folder)))
 
 (define-func gtk_file_chooser_get_current_folder
   string
@@ -121,7 +121,7 @@
 (define-func gtk_file_chooser_set_uri
   bool
   ((GtkFileChooser chooser)
-  ((tvec string in) uri)))
+  (string uri)))
 
 (define-func gtk_file_chooser_get_uri
   string
@@ -130,12 +130,12 @@
 (define-func gtk_file_chooser_select_uri
   bool
   ((GtkFileChooser chooser)
-   ((tvec string in) uri)))
+   (string uri)))
 
 (define-func gtk_file_chooser_unselect_uri
   none
   ((GtkFileChooser chooser)
-   ((tvec string in) uri)))
+   (string uri)))
 
 ;;; XXX need GSList return type support
 ;;(define-func gtk_file_chooser_get_uris
@@ -145,7 +145,7 @@
 (define-func gtk_file_chooser_set_current_folder_uri
   bool
   ((GtkFileChooser chooser)
-  ((tvec string in) uri)))
+  (string uri)))
 
 (define-func gtk_file_chooser_get_current_folder_uri
   string
@@ -210,7 +210,7 @@
 (define-func gtk_file_filter_set_name
   none
   ((GtkFileFilter filter)
-   ((tvec string in) name)))
+   (string name)))
 
 (define-func gtk_file_filter_get_name
   string
@@ -219,12 +219,12 @@
 (define-func gtk_file_filter_add_mime_type
   none
   ((GtkFileFilter filter)
-   ((tvec string in) mimetype)))
+   (string mimetype)))
 
 (define-func gtk_file_filter_add_pattern
   none
   ((GtkFileFilter filter)
-   ((tvec string in) pattern)))
+   (string pattern)))
 
 (define-func gtk_file_filter_add_pixbuf_formats
   none
@@ -280,13 +280,13 @@
 (define-func gtk_file_chooser_add_shortcut_folder
   bool
   ((GtkFileChooser chooser)
-   ((tvec string in) folder)
+   (string folder)
    (GPointer gerror error)))
 
 (define-func gtk_file_chooser_remove_shortcut_folder
   bool
   ((GtkFileChooser chooser)
-   ((tvec string in) folder)
+   (string folder)
    (GPointer gerror error)))
 
 ;; XXX Need GSList Returntype support
@@ -297,13 +297,13 @@
 (define-func gtk_file_chooser_add_shortcut_folder_uri
   bool
   ((GtkFileChooser chooser)
-   ((tvec string in) folder)
+   (string folder)
    (GPointer gerror error)))
 
 (define-func gtk_file_chooser_remove_shortcut_folder_uri
   bool
   ((GtkFileChooser chooser)
-   ((tvec string in) folder)
+   (string folder)
    (GPointer gerror error)))
 
 ;; XXX Need GSList Returntype support
@@ -322,4 +322,4 @@
 (define-func gtk_file_chooser_widget_new_with_backend
   GtkWidget
   ((GtkFileChooserAction action)
-   ((tvec string in) backend)))
+   (string backend)))

--- a/gtktree.defs
+++ b/gtktree.defs
@@ -280,7 +280,7 @@
   ((GtkTreeSelection selection)
    (GtkTreeModel model)
    (GtkTreePath path)
-   (bool selected)
+   (int selected)
    (GPointer data)))
 
 (define-boxed GtkTreeViewRowSeparatorFunc
@@ -378,7 +378,7 @@
   ((GtkCellRenderer cell)
    (GdkEvent event)
    (GtkWidget widget)
-   ((tvec string in) path)
+   (string path)
    ((tvec GdkRectangle in) background_area)
    ((tvec GdkRectangle in) cell_area)
    (GtkCellRendererState state)))
@@ -388,7 +388,7 @@
   ((GtkCellRenderer cell)
    (GdkEvent event)
    (GtkWidget widget)
-   ((tvec string in) path)
+   (string path)
    ((tvec GdkRectangle in) background_area)
    ((tvec GdkRectangle in) cell_area)
    (GtkCellRendererState state)))
@@ -526,7 +526,7 @@
   none
   ((GtkTreeViewColumn tv_column)
    (GtkCellRenderer cell)
-   ((tvec string in) attr)
+   (string attr)
    (int column)))
 
 (define-func gtk_tree_view_column_clear_attributes
@@ -613,7 +613,7 @@
 (define-func gtk_tree_view_column_set_title
   none
   ((GtkTreeViewColumn column)
-   ((tvec string in) title)))
+   (string title)))
 
 (define-func gtk_tree_view_column_get_title
   static_string
@@ -1087,8 +1087,8 @@
 (define-func gtk_tree_view_get_cursor
   none
   ((GtkTreeView tree)
-   (GtkTreePath path)
-   (GtkTreeViewColumn column)))
+   ((ret GtkTreePath) path)
+   ((ret GtkTreeViewColumn) column)))
 
 ;; GtkTreeView [Layout]
 
@@ -1101,8 +1101,8 @@
   ((GtkTreeView tree)
    (int x)
    (int y)
-   (GtkTreePath path)
-   (GtkTreeViewColumn column)
+   ((ret GtkTreePath) path)
+   ((ret GtkTreeViewColumn) column)
    ((ret int) cell_x)
    ((ret int) cell_y)))
 
@@ -1128,8 +1128,8 @@
 (define-func gtk_tree_view_get_visible_range
   bool
   ((GtkTreeView tree)
-   (GtkTreePath start)
-   (GtkTreePath end)))
+   ((ret GtkTreePath) start)
+   ((ret GtkTreePath) end)))
 
 ;; GtkTreeView [D-N-D]
 
@@ -1171,7 +1171,7 @@
 (define-func gtk_tree_view_get_drag_dest_row
   none
   ((GtkTreeView tree)
-   (GtkTreePath path)
+   ((ret GtkTreePath) path)
    ((tvec GtkTreeViewDropPosition in) pos)))
 
 (define-func gtk_tree_view_get_dest_row_at_pos
@@ -1179,7 +1179,7 @@
   ((GtkTreeView tree)
    (int x)
    (int y)
-   (GtkTreePath path)
+   ((ret GtkTreePath) path)
    ((tvec GtkTreeViewDropPosition in) pos)))
 
 (define-func gtk_tree_view_create_row_drag_icon

--- a/widgets/combobox
+++ b/widgets/combobox
@@ -57,7 +57,7 @@
 (define-func gtk_combo_box_set_title
   none
   ((GtkComboBox box)
-   ((tvec string in) title)))
+   (string title)))
 
 (define-func gtk_combo_box_get_title
   static_string

--- a/widgets/expander
+++ b/widgets/expander
@@ -4,11 +4,11 @@
 
 (define-func gtk_expander_new
   GtkWidget
-  (((tvec string in) label)))
+  ((string label)))
 
 (define-func gtk_expander_new_with_mnemonic
   GtkWidget
-  (((tvec string in) label)))
+  ((string label)))
 
 (define-func gtk_expander_set_expanded
   none
@@ -31,7 +31,7 @@
 (define-func gtk_expander_set_label
   none
   ((GtkExpander expander)
-   ((tvec string in) label)))
+   (string label)))
 
 (define-func gtk_expander_get_label
   static_string

--- a/widgets/filechooserbutton
+++ b/widgets/filechooserbutton
@@ -4,7 +4,7 @@
 
 (define-func gtk_file_chooser_button_new
   GtkWidget
-  (((tvec string in) title)
+  ((string title)
    (GtkFileChooserAction action)))
 
 (define-func gtk_file_chooser_button_new_with_dialog
@@ -14,7 +14,7 @@
 (define-func gtk_file_chooser_button_set_title
   none
   ((GtkFileChooserButton button)
-   ((tvec string in) title)))
+   (string title)))
 
 (define-func gtk_file_chooser_button_get_title
   static_string

--- a/widgets/scalebutton
+++ b/widgets/scalebutton
@@ -13,7 +13,7 @@
 (define-func gtk_scale_button_set_icons
   none
   ((GtkScaleButton button)
-   (string icons)))
+   ((tvec string in) icons)))
 
 (define-func gtk_scale_button_get_value
   double


### PR DESCRIPTION
GCC 14 will treat type errors like these as errors:

gtk-glue.c: In function 'Fgtk_window_get_position': gtk-glue.c:5321:38: error: passing argument 2 of 'gtk_window_get_position' makes pointer from integer without a cast
 5321 |   gtk_window_get_position (c_window, c_x, c_y);

Fix lot of these. See https://bugzilla.redhat.com/show_bug.cgi?id=2256944